### PR TITLE
- updated glibc patch to cover cfree() removal from glibc 2.26; relea…

### DIFF
--- a/clisp-glibc.patch
+++ b/clisp-glibc.patch
@@ -1,6 +1,6 @@
---- clisp-2.49/modules/bindings/glibc/linux.lisp~	2008-10-08 18:36:19.000000000 +0200
-+++ clisp-2.49/modules/bindings/glibc/linux.lisp	2012-12-12 12:50:41.830606483 +0100
-@@ -67,7 +66,7 @@
+--- clisp-2.49/modules/bindings/glibc/linux.lisp.orig	2008-10-08 18:36:19.000000000 +0200
++++ clisp-2.49/modules/bindings/glibc/linux.lisp	2017-12-05 15:58:10.508428262 +0100
+@@ -67,7 +67,7 @@
  (def-c-type __daddr_t)          ; int
  (def-c-type __caddr_t)          ; c-pointer
  (def-c-type __time_t)           ; long
@@ -18,7 +18,7 @@
  (def-c-type __ipc_pid_t)        ; ushort
  
  ; --------------------------- <sys/types.h> -----------------------------------
-@@ -294,6 +294,8 @@
+@@ -293,6 +293,8 @@
  ;; for robust mutexes
  (def-c-const EOWNERDEAD (:documentation "Owner died")) ; 130
  (def-c-const ENOTRECOVERABLE (:documentation "State not recoverable")) ; 131
@@ -27,3 +27,11 @@
  
  ; -------------------------- <bits/errno.h> -----------------------------------
  
+@@ -648,7 +650,6 @@
+ (def-call-out calloc (:arguments (nmemb size_t) (size size_t))
+   (:return-type c-pointer))
+ (def-call-out free (:arguments (ptr c-pointer)) (:return-type nil))
+-(def-call-out cfree (:arguments (ptr c-pointer)) (:return-type nil))
+ (def-call-out valloc (:arguments (size size_t)) (:return-type c-pointer))
+ 
+ (def-call-out abort (:arguments) (:return-type nil))

--- a/clisp.spec
+++ b/clisp.spec
@@ -1,5 +1,6 @@
 # TODO:
 # - review alpha patch
+# - unpackaged files (see the end of spec)
 #
 # Conditional build:
 %bcond_with	tests	# run test suite `make check' (uses network, won't pass on vserver)
@@ -9,8 +10,8 @@ Summary(pl.UTF-8):	Implementacja Common Lisp (ANSI CL)
 Summary(pt_BR.UTF-8):	Implementação do Common Lisp (ANSI CL)
 Name:		clisp
 Version:	2.49
-Release:	6
-License:	GPL
+Release:	7
+License:	GPL v2
 Group:		Development/Languages
 Source0:	http://download.sourceforge.net/clisp/%{name}-%{version}.tar.bz2
 # Source0-md5:	1962b99d5e530390ec3829236d168649
@@ -94,7 +95,6 @@ software livre, distribuído sob os termos da GNU GPL.
 #%{__perl} -pi -e "s@' -O2?([^0])@' %{rpmcflags} -fno-strict-aliasing\$1@" src/makemake.in
 
 %build
-
 %ifarch ppc ppc64
 ulimit -s unlimited
 %else


### PR DESCRIPTION
…se 7